### PR TITLE
Improve feed script and add sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Simple Next.js application that recommends vitamin products using OpenAI.
 
 ## Parsing product feed
 
-The script `scripts/parseFeed.ts` downloads the GymBeam product feed, filters vitamin related items and stores them into `public/vitamins.json`.
+The script `scripts/parseFeed.js` downloads the GymBeam product feed, filters vitamin related items and stores them into `public/vitamins.json`.
 Run it with:
 ```bash
-npm run parseFeed
+npm run parse:feed
 ```
+If network access is restricted, you can modify `public/vitamins.json` manually.
 
 ## Deployment on Vercel
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "parse:feed": "ts-node scripts/parseFeed.ts"
+    "parse:feed": "node scripts/parseFeed.js"
   },
   "dependencies": {
     "axios": "^1.6.7",

--- a/public/vitamins.json
+++ b/public/vitamins.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "id": "1",
+    "name": "Vitamin C 1000mg",
+    "url": "https://example.com/vitamin-c",
+    "price": "10.99",
+    "description": "High potency vitamin C to support immunity."
+  },
+  {
+    "id": "2",
+    "name": "Vitamin D3 2000 IU",
+    "url": "https://example.com/vitamin-d3",
+    "price": "8.50",
+    "description": "Vitamin D3 to maintain healthy bones and immune system."
+  },
+  {
+    "id": "3",
+    "name": "Multivitamin Complex",
+    "url": "https://example.com/multivitamin",
+    "price": "15.00",
+    "description": "Comprehensive daily multivitamin formula."
+  }
+]

--- a/scripts/parseFeed.js
+++ b/scripts/parseFeed.js
@@ -10,8 +10,8 @@ async function run() {
 
   const items = parsed?.SHOP?.SHOPITEM ?? [];
   const vitamins = items
-    .filter((item: any) => /vitamin/i.test(item?.CATEGORY?.[0] || '') || /vitamin/i.test(item?.PRODUCTNAME?.[0] || ''))
-    .map((item: any) => ({
+    .filter((item) => /vitamin/i.test(item?.CATEGORY?.[0] || '') || /vitamin/i.test(item?.PRODUCTNAME?.[0] || ''))
+    .map((item) => ({
       id: item?.ITEM_ID?.[0],
       name: item?.PRODUCTNAME?.[0],
       url: item?.URL?.[0],
@@ -24,7 +24,7 @@ async function run() {
   console.log(`Saved ${vitamins.length} vitamins to ${outPath}`);
 }
 
-run().catch(err => {
+run().catch((err) => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- convert `parseFeed` script to JavaScript so it works without ts-node
- document new `parse:feed` command and manual data editing option
- add sample vitamin data for offline use

## Testing
- `npm run parse:feed` *(fails: getaddrinfo ENOTFOUND affiliate.gymbeam.sk)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851472c984c8325968461256b8adaf1